### PR TITLE
Deprecate Desk for Medium recipes

### DIFF
--- a/Clove Labs/Desk-for-Medium.download.recipe
+++ b/Clove Labs/Desk-for-Medium.download.recipe
@@ -15,6 +15,15 @@
 		<string>1.0.0</string>
 		<key>Process</key>
 		<array>
+			<dict>
+				<key>Processor</key>
+				<string>DeprecationWarning</string>
+				<key>Arguments</key>
+				<dict>
+					<key>warning_message</key>
+					<string>The Desk app for Medium is discontinued (details: https://medium.com/desktop-app/download-9b9c3227f21). This recipe is deprecated and will be removed in the future.</string>
+				</dict>
+			</dict>
 			<!-- URLText Searcher -->
 			<dict>
 				<key>Arguments</key>


### PR DESCRIPTION
This PR deprecates the Desk app for Medium, as the software has been discontinued ([details](https://medium.com/desktop-app/download-9b9c3227f21)).
