### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Objective-See/DoNotDisturb.download.recipe
+++ b/Objective-See/DoNotDisturb.download.recipe
@@ -36,7 +36,11 @@
             <key>Processor</key>
             <string>URLDownloader</string>
         </dict>
-                <dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
             <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
@@ -55,10 +59,6 @@
             <key>requirement</key>
             <string>anchor apple generic and identifier "com.objective-see.dnd.installer" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
           </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/Objective-See/OverSight.download.recipe
+++ b/Objective-See/OverSight.download.recipe
@@ -38,6 +38,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -57,13 +61,6 @@
           </dict>
         </dict>
         <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/Objective-See/RansomWhere.download.recipe
+++ b/Objective-See/RansomWhere.download.recipe
@@ -41,6 +41,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -58,14 +62,6 @@
             <key>requirement</key>
             <string>anchor apple generic and identifier "com.objectiveSee.RansomWhere-Installer" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
           </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.